### PR TITLE
Size DSS /Contents dynamically with a retry fallback (#430)

### DIFF
--- a/engines/api/src/main/resources/net/sf/jsignpdf/conf/advanced.default.properties
+++ b/engines/api/src/main/resources/net/sf/jsignpdf/conf/advanced.default.properties
@@ -70,3 +70,13 @@ engine.dss.trust.certUrls=
 engine.dss.trust.truststoreFile=
 engine.dss.trust.truststoreType=
 engine.dss.trust.truststorePassword=
+#
+# Bytes reserved in the PDF /Contents for the CMS signature. 0 (default) sizes
+# it automatically from the certificate chain and options; set a positive value
+# to force a fixed size. Raise it only if signing fails with a "signature size
+# too small" error and retrying (below) is disabled.
+engine.dss.contentSize=0
+# Re-sign with a larger reservation if the reserved /Contents turns out too
+# small. Enabled by default; each retry repeats signing (and refetches the TSA
+# timestamp for level T and above).
+engine.dss.retryOnUndersize=true

--- a/engines/api/src/main/resources/net/sf/jsignpdf/translations/messages.properties
+++ b/engines/api/src/main/resources/net/sf/jsignpdf/translations/messages.properties
@@ -42,6 +42,8 @@ console.dss.socksProxyUnsupported=The DSS engine does not support SOCKS proxies;
 console.dss.unsupportedHash=The DSS engine does not support the hash algorithm ''{0}'' for PAdES. Use SHA-256, SHA-384 or SHA-512.
 console.dss.cannotEncryptSigned=Cannot encrypt a PDF that already contains signatures.
 console.dss.contentSizeRetry=The reserved signature size ({0} bytes) was too small; re-signing with {1} bytes.
+console.dss.contentSizeTooSmall=The reserved signature size ({0} bytes) is too small for this signature. Enable ''engine.dss.retryOnUndersize=true'' to grow it automatically, or set ''engine.dss.contentSize'' to at least {1} in the advanced configuration.
+console.dss.contentSizeExhausted=The signature still does not fit after growing the reserved size to {0} bytes. Set ''engine.dss.contentSize'' to at least {1} in the advanced configuration.
 console.dss.fontLoadFailed=Loading the visible-signature font failed: {0}
 console.getPrivateKey=Loading private key
 console.inFileNotFound.error=Input PDF was not found or it's not readable.

--- a/engines/api/src/main/resources/net/sf/jsignpdf/translations/messages.properties
+++ b/engines/api/src/main/resources/net/sf/jsignpdf/translations/messages.properties
@@ -41,6 +41,7 @@ console.dss.trustConfigFailed=Failed to load the configured DSS trust material (
 console.dss.socksProxyUnsupported=The DSS engine does not support SOCKS proxies; OCSP/CRL/AIA/TSA requests will bypass the proxy. Configure an HTTP proxy to route DSS revocation/timestamp traffic.
 console.dss.unsupportedHash=The DSS engine does not support the hash algorithm ''{0}'' for PAdES. Use SHA-256, SHA-384 or SHA-512.
 console.dss.cannotEncryptSigned=Cannot encrypt a PDF that already contains signatures.
+console.dss.contentSizeRetry=The reserved signature size ({0} bytes) was too small; re-signing with {1} bytes.
 console.dss.fontLoadFailed=Loading the visible-signature font failed: {0}
 console.getPrivateKey=Loading private key
 console.inFileNotFound.error=Input PDF was not found or it's not readable.

--- a/engines/dss/src/main/java/net/sf/jsignpdf/engine/dss/DssSigningEngine.java
+++ b/engines/dss/src/main/java/net/sf/jsignpdf/engine/dss/DssSigningEngine.java
@@ -15,6 +15,7 @@ import java.net.Proxy;
 import java.net.URI;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -23,6 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
@@ -82,6 +85,47 @@ public class DssSigningEngine implements SigningEngine {
 
     /** Stable identifier used in config files and CLI args. */
     public static final String ID = "dss";
+
+    /**
+     * Config key ({@code engine.dss.contentSize}): explicit number of bytes to reserve in the PDF
+     * {@code /Contents} for the CMS signature. A positive value overrides the automatic estimate; {@code 0}
+     * (the default / absent) means the size is estimated from the certificate chain and signing options.
+     */
+    static final String KEY_CONTENT_SIZE = "contentSize";
+
+    /**
+     * Config key ({@code engine.dss.retryOnUndersize}): when {@code true} (the default), the signature is
+     * re-created with a larger reserved {@code /Contents} if DSS reports the reserved size was too small.
+     * The retry repeats the signing operation (and, for timestamped levels, fetches a fresh TSA token).
+     */
+    static final String KEY_RETRY_ON_UNDERSIZE = "retryOnUndersize";
+
+    /** Lower bound for the reserved {@code /Contents} size, matching DSS's own default; never estimate below it. */
+    private static final int MIN_CONTENT_SIZE = 9472;
+
+    /** Per-certificate fallback used only when a chain certificate cannot be DER-encoded for measurement. */
+    private static final int CERT_SIZE_FALLBACK = 2048;
+
+    /**
+     * Headroom added on top of the certificate-chain bytes for the signer info, signed attributes, the
+     * signature value (comfortably covers RSA-4096) and the ASN.1 framing of the CMS SignedData.
+     */
+    private static final int CMS_OVERHEAD = 4096;
+
+    /**
+     * Extra space reserved when a signature timestamp is embedded (PAdES level T and above). The timestamp
+     * token carries its own TSA certificate chain and is by far the largest single variable in {@code /Contents}.
+     */
+    private static final int TSA_ALLOWANCE = 16384;
+
+    /** Slack added on top of the exact size DSS reports when growing after an undersize failure. */
+    private static final int RETRY_MARGIN = 2048;
+
+    /** Cap on undersize retries; DSS reports the exact required size, so a single retry normally suffices. */
+    private static final int MAX_CONTENT_SIZE_RETRIES = 3;
+
+    /** Extracts the actual CMS length from the DSS "signature size too small" message; see {@code assertContentSizeSufficient}. */
+    private static final Pattern UNDERSIZE_LENGTH_PATTERN = Pattern.compile("with a length \\[(\\d+)\\]");
 
     private static final Set<Capability> CAPABILITIES = Set.copyOf(EnumSet.of(
             Capability.SUBFILTER_ETSI_CADES_DETACHED,
@@ -263,9 +307,13 @@ public class DssSigningEngine implements SigningEngine {
 
                 LOGGER.info(RES.get("console.processing"));
                 LOGGER.info(RES.get("console.createSignature"));
-                final ToBeSigned dataToSign = service.getDataToSign(document, parameters);
-                final SignatureValue signatureValue = token.sign(dataToSign, digestAlgorithm, null);
-                final DSSDocument signedDocument = service.signDocument(document, parameters, signatureValue);
+                final int configuredContentSize = engineConfig.getInt(KEY_CONTENT_SIZE, 0);
+                final int initialContentSize = configuredContentSize > 0
+                        ? configuredContentSize
+                        : estimateContentSize(chain, useTsa);
+                final boolean retryOnUndersize = engineConfig.getBoolean(KEY_RETRY_ON_UNDERSIZE, true);
+                final DSSDocument signedDocument = signWithContentSize(service, document, parameters, token,
+                        digestAlgorithm, initialContentSize, retryOnUndersize);
 
                 LOGGER.info(RES.get("console.createOutPdf", outFile));
                 try (FileOutputStream fos = new FileOutputStream(outFile)) {
@@ -284,6 +332,93 @@ public class DssSigningEngine implements SigningEngine {
             }
         }
         return finished;
+    }
+
+    /**
+     * Estimates how many bytes to reserve in the PDF {@code /Contents} for the CMS signature. DSS uses a
+     * fixed reservation (default {@value #MIN_CONTENT_SIZE}) that is too small for large certificate chains
+     * (e.g. eID / qualified certificates) combined with an embedded signature timestamp, which is exactly the
+     * case reported in issue #430. Sizing from the actual chain (plus a fixed timestamp allowance) covers
+     * those in a single pass; {@link #signWithContentSize} is the safety net when even this is too small.
+     *
+     * <p>
+     * The estimate cannot be exact for timestamped signatures: the TSA token (with its own certificate chain)
+     * is only known after the TSA responds inside {@code signDocument()}, so a fixed {@link #TSA_ALLOWANCE} is
+     * reserved instead.
+     * </p>
+     *
+     * @param chain         the signer's certificate chain (all of it is encapsulated in the CMS)
+     * @param withTimestamp whether a signature timestamp will be embedded (PAdES level T and above)
+     * @return the number of bytes to reserve, never below {@link #MIN_CONTENT_SIZE}
+     */
+    private static int estimateContentSize(Certificate[] chain, boolean withTimestamp) {
+        int chainBytes = 0;
+        for (Certificate cert : chain) {
+            try {
+                chainBytes += cert.getEncoded().length;
+            } catch (CertificateEncodingException e) {
+                chainBytes += CERT_SIZE_FALLBACK;
+            }
+        }
+        int estimate = chainBytes + CMS_OVERHEAD;
+        if (withTimestamp) {
+            estimate += TSA_ALLOWANCE;
+        }
+        return Math.max(estimate, MIN_CONTENT_SIZE);
+    }
+
+    /**
+     * Signs the document, reserving {@code initialContentSize} bytes for the CMS {@code /Contents}. The
+     * reserved size is fixed before the byte ranges are digested, so it cannot be derived from the produced
+     * signature; when {@code retryOnUndersize} is enabled and DSS reports the reservation was too small, this
+     * re-runs the whole signing operation with the exact size DSS reported (plus {@link #RETRY_MARGIN}). For
+     * timestamped levels each retry fetches a fresh TSA token, hence the {@link #MAX_CONTENT_SIZE_RETRIES} cap.
+     */
+    private DSSDocument signWithContentSize(PAdESService service, DSSDocument document,
+            PAdESSignatureParameters parameters, PrivateKeySignatureToken token, DigestAlgorithm digestAlgorithm,
+            int initialContentSize, boolean retryOnUndersize) {
+        int contentSize = initialContentSize;
+        for (int attempt = 0;; attempt++) {
+            parameters.setContentSize(contentSize);
+            final ToBeSigned dataToSign = service.getDataToSign(document, parameters);
+            final SignatureValue signatureValue = token.sign(dataToSign, digestAlgorithm, null);
+            try {
+                return service.signDocument(document, parameters, signatureValue);
+            } catch (IllegalArgumentException e) {
+                final Integer required = parseRequiredContentSize(e.getMessage());
+                if (!retryOnUndersize || attempt >= MAX_CONTENT_SIZE_RETRIES) {
+                    throw e;
+                }
+                final int grown = required != null ? required + RETRY_MARGIN : contentSize * 2;
+                if (grown <= contentSize) {
+                    // No forward progress (unparseable message and overflow guard); stop rather than loop.
+                    throw e;
+                }
+                LOGGER.info(RES.get("console.dss.contentSizeRetry", String.valueOf(contentSize),
+                        String.valueOf(grown)));
+                contentSize = grown;
+            }
+        }
+    }
+
+    /**
+     * Parses the required CMS length out of the DSS "signature size is too small" message, so the retry can
+     * reserve exactly that (plus a margin). Returns {@code null} when the message does not match, in which case
+     * the caller falls back to doubling.
+     */
+    private static Integer parseRequiredContentSize(String message) {
+        if (message == null) {
+            return null;
+        }
+        final Matcher matcher = UNDERSIZE_LENGTH_PATTERN.matcher(message);
+        if (matcher.find()) {
+            try {
+                return Integer.valueOf(matcher.group(1));
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private OnlineTSPSource buildTspSource(BasicSignerOptions options, PAdESSignatureParameters parameters,

--- a/engines/dss/src/main/java/net/sf/jsignpdf/engine/dss/DssSigningEngine.java
+++ b/engines/dss/src/main/java/net/sf/jsignpdf/engine/dss/DssSigningEngine.java
@@ -386,18 +386,37 @@ public class DssSigningEngine implements SigningEngine {
                 return service.signDocument(document, parameters, signatureValue);
             } catch (IllegalArgumentException e) {
                 final Integer required = parseRequiredContentSize(e.getMessage());
-                if (!retryOnUndersize || attempt >= MAX_CONTENT_SIZE_RETRIES) {
-                    throw e;
-                }
+                // Doubling is the fallback when the required size cannot be parsed; the guard below stops a
+                // non-growing loop in that case.
                 final int grown = required != null ? required + RETRY_MARGIN : contentSize * 2;
-                if (grown <= contentSize) {
-                    // No forward progress (unparseable message and overflow guard); stop rather than loop.
+                if (!retryOnUndersize || attempt >= MAX_CONTENT_SIZE_RETRIES || grown <= contentSize) {
+                    logUndersizeGuidance(contentSize, required, retryOnUndersize);
                     throw e;
                 }
                 LOGGER.info(RES.get("console.dss.contentSizeRetry", String.valueOf(contentSize),
                         String.valueOf(grown)));
                 contentSize = grown;
             }
+        }
+    }
+
+    /**
+     * Logs an actionable message when an undersized {@code /Contents} cannot be recovered, pointing the user at
+     * the two knobs that control it: the automatic {@code engine.dss.retryOnUndersize} growth (when it is
+     * switched off) and the explicit {@code engine.dss.contentSize} reservation. Without this the only feedback
+     * is the raw DSS {@link IllegalArgumentException}, which names {@code setContentSize(...)} (a DSS API call)
+     * rather than the JSignPdf setting.
+     *
+     * @param contentSize the reservation that proved too small
+     * @param required    the size DSS reported as needed, or {@code null} if it could not be parsed
+     */
+    private static void logUndersizeGuidance(int contentSize, Integer required, boolean retryOnUndersize) {
+        final String suggested = String.valueOf((required != null ? required : contentSize * 2) + RETRY_MARGIN);
+        if (retryOnUndersize) {
+            // Retry was enabled but exhausted/non-progressing: only the explicit override is left.
+            LOGGER.severe(RES.get("console.dss.contentSizeExhausted", String.valueOf(contentSize), suggested));
+        } else {
+            LOGGER.severe(RES.get("console.dss.contentSizeTooSmall", String.valueOf(contentSize), suggested));
         }
     }
 

--- a/engines/dss/src/test/java/net/sf/jsignpdf/engine/dss/DssSigningEngineTest.java
+++ b/engines/dss/src/test/java/net/sf/jsignpdf/engine/dss/DssSigningEngineTest.java
@@ -149,6 +149,39 @@ public class DssSigningEngineTest {
     }
 
     @Test
+    public void undersizedContentSizeRecoversViaRetry() throws Exception {
+        BasicSignerOptions o = baseOptions();
+        // A deliberately tiny reservation forces DSS's "signature size too small" error. With the retry
+        // enabled by default, the engine must grow the reservation and still produce a valid signature.
+        Map<String, String> cfg = new HashMap<>();
+        cfg.put(DssSigningEngine.KEY_CONTENT_SIZE, "100");
+        assertTrue("undersize must be recovered by the retry",
+                new DssSigningEngine().sign(o, new MapEngineConfig(cfg)));
+        assertSignatureLevel(outputFile, SignatureLevel.PAdES_BASELINE_B);
+    }
+
+    @Test
+    public void undersizedContentSizeFailsWhenRetryDisabled() throws Exception {
+        BasicSignerOptions o = baseOptions();
+        Map<String, String> cfg = new HashMap<>();
+        cfg.put(DssSigningEngine.KEY_CONTENT_SIZE, "100");
+        cfg.put(DssSigningEngine.KEY_RETRY_ON_UNDERSIZE, "false");
+        // With the retry switched off, a too-small reservation must fail rather than silently grow.
+        assertFalse("undersize must fail when the retry is disabled",
+                new DssSigningEngine().sign(o, new MapEngineConfig(cfg)));
+    }
+
+    @Test
+    public void explicitContentSizeSignsSuccessfully() throws Exception {
+        BasicSignerOptions o = baseOptions();
+        Map<String, String> cfg = new HashMap<>();
+        cfg.put(DssSigningEngine.KEY_CONTENT_SIZE, "32768");
+        assertTrue("a generous explicit content size must sign in one pass",
+                new DssSigningEngine().sign(o, new MapEngineConfig(cfg)));
+        assertSignatureLevel(outputFile, SignatureLevel.PAdES_BASELINE_B);
+    }
+
+    @Test
     public void baselineBWithTsaUpgradesToT() throws Exception {
         BasicSignerOptions o = baseOptions(); // padesLevel == null -> BASELINE_B, auto-upgraded to T by the TSA
         useEmbeddedTsa(o);


### PR DESCRIPTION
## Problem

The new EU DSS (PAdES) engine reserved DSS's fixed default of **9472 bytes** for the CMS signature `/Contents`. That is too small for large certificate chains (eID / qualified certs) combined with an embedded signature timestamp, so signing consistently failed with:

> The signature size [9472] is too small for the signature value with a length [14380].

Fixes #430.

## Approach

The reservation must be fixed *before* the byte ranges are digested, so it cannot be derived from the produced signature. Instead:

1. **Estimate up front** from the actual certificate chain (`Σ cert.getEncoded().length`) + overhead for the signer info / signed attributes / signature value / ASN.1 framing, plus a fixed TSA allowance when a timestamp is embedded. This covers the eID+TSA case in a single pass.
2. **Grow-and-resign** as a safety net: if DSS still reports the reservation too small, parse the exact required length, grow by a margin and re-sign (capped, with a no-progress guard). For timestamped levels each retry refetches the TSA token, hence the cap.

Both behaviours are configurable via `EngineConfig`:

| Key | Default | Meaning |
|-----|---------|---------|
| `engine.dss.contentSize` | `0` | Explicit reserved `/Contents` size in bytes; `0` = auto-estimate |
| `engine.dss.retryOnUndersize` | `true` | Grow the reservation and re-sign if DSS reports it too small |

## Tradeoffs

- Common eID+TSA case now signs in **one pass** — no double TSA call, no PKCS#11 PIN re-prompt.
- The retry path repeats signing (and refetches a TSA token), so it is capped; the generous up-front estimate keeps it off the hot path.
- The only residual fragility is parsing the required size out of DSS's exception message text (DSS exposes no typed getter); that path is a fallback and degrades gracefully to doubling.

## Tests

Added 3 tests (14 total, all green):
- undersize recovers via retry
- undersize fails when retry disabled
- generous explicit content size signs in one pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)