### PR TITLE
UX: remember last directory and zoom level; add support for jbig2/jpeg2000 to preview

### DIFF
--- a/jsignpdf/pom.xml
+++ b/jsignpdf/pom.xml
@@ -164,14 +164,6 @@
             <artifactId>jbig2-imageio</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.jai-imageio</groupId>
-            <artifactId>jai-imageio-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.jai-imageio</groupId>
-            <artifactId>jai-imageio-jpeg2000</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.kwart.jsign</groupId>
             <artifactId>jsign-jpedal</artifactId>
         </dependency>

--- a/jsignpdf/pom.xml
+++ b/jsignpdf/pom.xml
@@ -160,6 +160,18 @@
             <artifactId>pdfbox</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>jbig2-imageio</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-jpeg2000</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.kwart.jsign</groupId>
             <artifactId>jsign-jpedal</artifactId>
         </dependency>

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/fx/view/MainWindowController.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/fx/view/MainWindowController.java
@@ -67,8 +67,6 @@ import net.sf.jsignpdf.fx.preset.ManagePresetsDialog;
 import net.sf.jsignpdf.fx.preset.Preset;
 import net.sf.jsignpdf.fx.preset.PresetManager;
 import net.sf.jsignpdf.fx.preset.PresetValidation;
-import net.sf.jsignpdf.utils.PropertyProvider;
-import net.sf.jsignpdf.utils.PropertyStoreFactory;
 import net.sf.jsignpdf.fx.util.RecentFilesManager;
 import net.sf.jsignpdf.fx.viewmodel.DocumentViewModel;
 import net.sf.jsignpdf.fx.viewmodel.SignaturePlacementViewModel;
@@ -76,6 +74,8 @@ import net.sf.jsignpdf.fx.viewmodel.SigningOptionsViewModel;
 import net.sf.jsignpdf.fx.viewmodel.VisibleSignatureCoordinator;
 import net.sf.jsignpdf.types.PadesLevel;
 import net.sf.jsignpdf.types.PageInfo;
+import net.sf.jsignpdf.utils.PropertyProvider;
+import net.sf.jsignpdf.utils.PropertyStoreFactory;
 
 import static net.sf.jsignpdf.Constants.LOGGER;
 import static net.sf.jsignpdf.Constants.RES;
@@ -84,6 +84,9 @@ import static net.sf.jsignpdf.Constants.RES;
  * Controller for the main application window.
  */
 public class MainWindowController {
+
+    private static final String KEY_LAST_OPEN_DIR = "last.open.dir";
+    private static final String KEY_LAST_ZOOM = "last.zoom";
 
     private Stage stage;
     private File lastOpenDir;
@@ -355,14 +358,13 @@ public class MainWindowController {
             }
         });
 
-        // Zoom level changes update combo, remember the last zoom, and persist
+        // Zoom level changes update combo and remember the last zoom (persisted on document open / exit)
         documentVM.zoomLevelProperty().addListener((obs, oldVal, newVal) -> {
             lastZoomLevel = newVal.doubleValue();
             String formatted = Math.round(newVal.doubleValue() * 100) + "%";
             if (!formatted.equals(cmbZoom.getValue())) {
                 cmbZoom.setValue(formatted);
             }
-            saveViewStateToConfig();
         });
 
         // Page number text field commit
@@ -945,8 +947,6 @@ public class MainWindowController {
         }
         File file = fc.showOpenDialog(stage);
         if (file != null) {
-            lastOpenDir = file.getParentFile();
-            saveLastOpenDir();
             openDocument(file);
         }
     }
@@ -1197,6 +1197,7 @@ public class MainWindowController {
 
     private void openDocument(File file) {
         lastOpenDir = file.getParentFile();
+        saveViewStateToConfig();
         try {
             if (options == null) {
                 options = new BasicSignerOptions();
@@ -1355,18 +1356,6 @@ public class MainWindowController {
         stage.setTitle("JSignPdf " + Constants.VERSION);
     }
 
-    private static final String KEY_LAST_OPEN_DIR = "last.open.dir";
-    private static final String KEY_LAST_ZOOM = "last.zoom";
-
-    private void saveLastOpenDir() {
-        try {
-            PropertyProvider cfg = PropertyStoreFactory.getInstance().mainConfig();
-            cfg.setProperty(KEY_LAST_OPEN_DIR, lastOpenDir.getAbsolutePath());
-            cfg.save();
-        } catch (Exception ignored) {
-        }
-    }
-
     private void loadPersistedViewState() {
         try {
             PropertyProvider cfg = PropertyStoreFactory.getInstance().mainConfig();
@@ -1381,16 +1370,21 @@ public class MainWindowController {
             if (zoom != null) {
                 lastZoomLevel = Double.parseDouble(zoom);
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Could not load persisted view state", e);
         }
     }
 
     private void saveViewStateToConfig() {
         try {
             PropertyProvider cfg = PropertyStoreFactory.getInstance().mainConfig();
+            if (lastOpenDir != null) {
+                cfg.setProperty(KEY_LAST_OPEN_DIR, lastOpenDir.getAbsolutePath());
+            }
             cfg.setProperty(KEY_LAST_ZOOM, String.valueOf(lastZoomLevel));
             cfg.save();
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Could not persist view state", e);
         }
     }
 

--- a/jsignpdf/src/main/java/net/sf/jsignpdf/fx/view/MainWindowController.java
+++ b/jsignpdf/src/main/java/net/sf/jsignpdf/fx/view/MainWindowController.java
@@ -67,9 +67,10 @@ import net.sf.jsignpdf.fx.preset.ManagePresetsDialog;
 import net.sf.jsignpdf.fx.preset.Preset;
 import net.sf.jsignpdf.fx.preset.PresetManager;
 import net.sf.jsignpdf.fx.preset.PresetValidation;
+import net.sf.jsignpdf.utils.PropertyProvider;
+import net.sf.jsignpdf.utils.PropertyStoreFactory;
 import net.sf.jsignpdf.fx.util.RecentFilesManager;
 import net.sf.jsignpdf.fx.viewmodel.DocumentViewModel;
-import net.sf.jsignpdf.utils.PropertyStoreFactory;
 import net.sf.jsignpdf.fx.viewmodel.SignaturePlacementViewModel;
 import net.sf.jsignpdf.fx.viewmodel.SigningOptionsViewModel;
 import net.sf.jsignpdf.fx.viewmodel.VisibleSignatureCoordinator;
@@ -85,6 +86,8 @@ import static net.sf.jsignpdf.Constants.RES;
 public class MainWindowController {
 
     private Stage stage;
+    private File lastOpenDir;
+    private double lastZoomLevel = 1.0;
     private BasicSignerOptions options;
     private final DocumentViewModel documentVM = new DocumentViewModel();
     private final SigningOptionsViewModel signingVM = new SigningOptionsViewModel();
@@ -319,6 +322,7 @@ public class MainWindowController {
 
         progressBar.setVisible(false);
         updateStatus(RES.get("jfx.gui.status.ready"));
+        loadPersistedViewState();
 
         cmbZoom.getItems().addAll("50%", "75%", "100%", "125%", "150%", "200%");
         cmbZoom.setValue("100%");
@@ -351,12 +355,14 @@ public class MainWindowController {
             }
         });
 
-        // Zoom level changes update combo
+        // Zoom level changes update combo, remember the last zoom, and persist
         documentVM.zoomLevelProperty().addListener((obs, oldVal, newVal) -> {
+            lastZoomLevel = newVal.doubleValue();
             String formatted = Math.round(newVal.doubleValue() * 100) + "%";
             if (!formatted.equals(cmbZoom.getValue())) {
                 cmbZoom.setValue(formatted);
             }
+            saveViewStateToConfig();
         });
 
         // Page number text field commit
@@ -931,11 +937,16 @@ public class MainWindowController {
 
     @FXML
     private void onFileOpen() {
-        File file = new NativeFileChooser()
+        NativeFileChooser fc = new NativeFileChooser()
                 .setTitle(RES.get("jfx.gui.dialog.openPdf.title"))
-                .addFilter(ExtensionFilter.of("PDF Files", "*.pdf"))
-                .showOpenDialog(stage);
+                .addFilter(ExtensionFilter.of("PDF Files", "*.pdf"));
+        if (lastOpenDir != null) {
+            fc.setInitialDirectory(lastOpenDir);
+        }
+        File file = fc.showOpenDialog(stage);
         if (file != null) {
+            lastOpenDir = file.getParentFile();
+            saveLastOpenDir();
             openDocument(file);
         }
     }
@@ -947,6 +958,7 @@ public class MainWindowController {
 
     @FXML
     private void onFileExit() {
+        saveViewStateToConfig();
         stage.close();
     }
 
@@ -1184,6 +1196,7 @@ public class MainWindowController {
     // --- Document handling ---
 
     private void openDocument(File file) {
+        lastOpenDir = file.getParentFile();
         try {
             if (options == null) {
                 options = new BasicSignerOptions();
@@ -1218,13 +1231,13 @@ public class MainWindowController {
 
             documentVM.setDocumentFile(file);
             documentVM.setPageCount(pages);
-            documentVM.setZoomLevel(1.0);
+            documentVM.setZoomLevel(lastZoomLevel);
 
             lblDropHint.setVisible(false);
             setDocumentControlsDisabled(false);
             lblPageCount.setText("/ " + pages);
             txtPageNumber.setText("1");
-            cmbZoom.setValue("100%");
+            cmbZoom.setValue(Math.round(lastZoomLevel * 100) + "%");
 
             stage.setTitle("JSignPdf " + Constants.VERSION + " - " + file.getName());
             LOGGER.info("Opened document: " + file.getAbsolutePath());
@@ -1340,6 +1353,45 @@ public class MainWindowController {
         updateOutputPathLabel();
         updateSigStateBadge();
         stage.setTitle("JSignPdf " + Constants.VERSION);
+    }
+
+    private static final String KEY_LAST_OPEN_DIR = "last.open.dir";
+    private static final String KEY_LAST_ZOOM = "last.zoom";
+
+    private void saveLastOpenDir() {
+        try {
+            PropertyProvider cfg = PropertyStoreFactory.getInstance().mainConfig();
+            cfg.setProperty(KEY_LAST_OPEN_DIR, lastOpenDir.getAbsolutePath());
+            cfg.save();
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void loadPersistedViewState() {
+        try {
+            PropertyProvider cfg = PropertyStoreFactory.getInstance().mainConfig();
+            String dir = cfg.getProperty(KEY_LAST_OPEN_DIR);
+            if (dir != null && !dir.isEmpty()) {
+                File f = new File(dir);
+                if (f.isDirectory()) {
+                    lastOpenDir = f;
+                }
+            }
+            String zoom = cfg.getProperty(KEY_LAST_ZOOM);
+            if (zoom != null) {
+                lastZoomLevel = Double.parseDouble(zoom);
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void saveViewStateToConfig() {
+        try {
+            PropertyProvider cfg = PropertyStoreFactory.getInstance().mainConfig();
+            cfg.setProperty(KEY_LAST_ZOOM, String.valueOf(lastZoomLevel));
+            cfg.save();
+        } catch (Exception ignored) {
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
         <jsign.pkcs11.version>1.1.0</jsign.pkcs11.version>
         <jsign.jpedal.version>4.92.13</jsign.jpedal.version>
         <pdfbox.version>3.0.7</pdfbox.version>
+        <jbig2-imageio.version>3.0.2</jbig2-imageio.version>
+        <jai-imageio-jpeg2000.version>1.4.0</jai-imageio-jpeg2000.version>
         <commons-io.version>2.22.0</commons-io.version>
         <commons-cli.version>1.11.0</commons-cli.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
@@ -112,6 +114,11 @@
                 <version>${pdfbox.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>jbig2-imageio</artifactId>
+                <version>${jbig2-imageio.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.kwart.jsign</groupId>
                 <artifactId>jsign-jpedal</artifactId>
                 <version>${jsign.jpedal.version}</version>
@@ -126,11 +133,15 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
             </dependency>
-            <!-- We don't use the following jai-imageio dependency. We unify the version to make the enforcer's DependencyConvergence rule happy. -->
             <dependency>
                 <groupId>com.github.jai-imageio</groupId>
                 <artifactId>jai-imageio-core</artifactId>
                 <version>1.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jai-imageio</groupId>
+                <artifactId>jai-imageio-jpeg2000</artifactId>
+                <version>${jai-imageio-jpeg2000.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <jsign.jpedal.version>4.92.13</jsign.jpedal.version>
         <pdfbox.version>3.0.7</pdfbox.version>
         <jbig2-imageio.version>3.0.2</jbig2-imageio.version>
-        <jai-imageio-jpeg2000.version>1.4.0</jai-imageio-jpeg2000.version>
         <commons-io.version>2.22.0</commons-io.version>
         <commons-cli.version>1.11.0</commons-cli.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
@@ -133,15 +132,11 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
             </dependency>
+            <!-- We don't use the following jai-imageio dependency. We unify the version to make the enforcer's DependencyConvergence rule happy. -->
             <dependency>
                 <groupId>com.github.jai-imageio</groupId>
                 <artifactId>jai-imageio-core</artifactId>
                 <version>1.4.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.jai-imageio</groupId>
-                <artifactId>jai-imageio-jpeg2000</artifactId>
-                <version>${jai-imageio-jpeg2000.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- Remember chosen directory in File > Open across invocations, persisted to config.properties.
- Remember zoom level across document loads, persisted to config.properties.
- Add jbig2-imageio and jai-imageio-jpeg2000 dependencies so the PDF preview can render optimized/reduced-size PDFs.