### PR TITLE
Preserve image aspect ratio in DSS visible signatures (#460)

### DIFF
--- a/engines/dss/src/main/java/net/sf/jsignpdf/engine/dss/DssSigningEngine.java
+++ b/engines/dss/src/main/java/net/sf/jsignpdf/engine/dss/DssSigningEngine.java
@@ -56,6 +56,7 @@ import org.apache.pdfbox.pdmodel.common.PDRectangle;
 
 import eu.europa.esig.dss.enumerations.CertificationPermission;
 import eu.europa.esig.dss.enumerations.DigestAlgorithm;
+import eu.europa.esig.dss.enumerations.ImageScaling;
 import eu.europa.esig.dss.enumerations.SignatureLevel;
 import eu.europa.esig.dss.model.DSSDocument;
 import eu.europa.esig.dss.model.FileDocument;
@@ -141,7 +142,8 @@ public class DssSigningEngine implements SigningEngine {
             Capability.ENCRYPTION_PASSWORD, Capability.PERMISSIONS_BITMASK,
 
             Capability.VISIBLE_SIGNATURE, Capability.VISIBLE_LAYER2_TEXT,
-            Capability.VISIBLE_BACKGROUND_IMAGE, Capability.VISIBLE_SIGNATURE_GRAPHIC,
+            Capability.VISIBLE_BACKGROUND_IMAGE, Capability.VISIBLE_BACKGROUND_IMAGE_SCALE,
+            Capability.VISIBLE_SIGNATURE_GRAPHIC,
             Capability.VISIBLE_CUSTOM_FONT,
             Capability.VISIBLE_RENDER_MODE_DESCRIPTION_ONLY,
             Capability.VISIBLE_RENDER_MODE_GRAPHIC_AND_DESCRIPTION,
@@ -644,6 +646,7 @@ public class DssSigningEngine implements SigningEngine {
         if (imagePath != null) {
             LOGGER.info(RES.get("console.createImage", imagePath));
             imageParams.setImage(new FileDocument(imagePath));
+            imageParams.setImageScaling(imageScalingFor(options.getBgImgScale()));
         }
 
         LOGGER.info(RES.get("console.setL2Text"));
@@ -661,6 +664,11 @@ public class DssSigningEngine implements SigningEngine {
         imageParams.setTextParameters(textParams);
 
         parameters.setImageParameters(imageParams);
+    }
+
+    // bgImgScale mirrors OpenPDF: 0 = stretch to fill, otherwise fit preserving aspect ratio.
+    static ImageScaling imageScalingFor(float bgImgScale) {
+        return bgImgScale == 0f ? ImageScaling.STRETCH : ImageScaling.ZOOM_AND_CENTER;
     }
 
     private String buildSignatureText(BasicSignerOptions options, Certificate[] chain, Calendar signingCal) {

--- a/engines/dss/src/test/java/net/sf/jsignpdf/engine/dss/DssSigningEngineTest.java
+++ b/engines/dss/src/test/java/net/sf/jsignpdf/engine/dss/DssSigningEngineTest.java
@@ -37,6 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import eu.europa.esig.dss.enumerations.ImageScaling;
 import eu.europa.esig.dss.enumerations.SignatureLevel;
 import eu.europa.esig.dss.model.FileDocument;
 import eu.europa.esig.dss.simplereport.SimpleReport;
@@ -270,6 +271,19 @@ public class DssSigningEngineTest {
             assertEquals("visible signature width", 200f, rect.getWidth(), 1f);
             assertEquals("visible signature height", 150f, rect.getHeight(), 1f);
         }
+    }
+
+    @Test
+    public void bgImgScaleMapsToImageScaling() {
+        // Default (-1) and any non-zero value preserve aspect ratio; 0 stretches to fill (issue #460).
+        assertEquals(ImageScaling.ZOOM_AND_CENTER, DssSigningEngine.imageScalingFor(-1f));
+        assertEquals(ImageScaling.ZOOM_AND_CENTER, DssSigningEngine.imageScalingFor(2f));
+        assertEquals(ImageScaling.STRETCH, DssSigningEngine.imageScalingFor(0f));
+    }
+
+    @Test
+    public void capabilitiesDeclareBackgroundImageScale() {
+        assertTrue(new DssSigningEngine().capabilities().contains(Capability.VISIBLE_BACKGROUND_IMAGE_SCALE));
     }
 
     @Test

--- a/website/docs/JSignPdf.adoc
+++ b/website/docs/JSignPdf.adoc
@@ -499,7 +499,7 @@ See <<Visible signature options>> for details.
 | Background image path for the visible signature.
 
 | `--bg-scale <scale>`
-| Background image scale. Positive: multiply size. Zero: stretch to fill. Negative: best-fit resize.
+| Background image scale. Positive: multiply size. Zero: stretch to fill. Negative: best-fit resize. The DSS (PAdES) engine only distinguishes stretch (zero) from aspect-ratio-preserving fit (any non-zero value); it does not apply positive values as absolute scale factors.
 
 | `--disable-acrobat6-layer-mode`
 | Disable Acrobat 6 layer mode (creates all signature layers instead of just n2 and n4).


### PR DESCRIPTION
The DSS engine left `SignatureImageParameters` at `ImageScaling.STRETCH`, so background/graphic images were stretched to fill the signature box and distorted (#460). OpenPDF already preserves the ratio via `bgImgScale`.

- Map `bgImgScale` to DSS scaling: `0` = stretch, otherwise fit + center (`ZOOM_AND_CENTER`), mirroring OpenPDF semantics.
- Declare `Capability.VISIBLE_BACKGROUND_IMAGE_SCALE` on the DSS engine.
- Add tests for the mapping and the new capability.

Note: DSS only distinguishes stretch vs. fit; positive `bgImgScale` factors (absolute scaling in OpenPDF) fold into fit-and-center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)