### PR TITLE
Set SourceForge per-platform default downloads on release

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -579,12 +579,8 @@ jobs:
         rm -f private_key
 
     - name: Set SourceForge default downloads (final releases only)
-      # Without this, SourceForge's per-platform "Download Latest Version" flag
-      # stays wherever it was last set (it does NOT auto-follow new uploads), so
-      # visitors keep getting an ancient installer. The Release API sets the
-      # default per file; PUTting the flag onto the new file moves it off the old
-      # one. Skipped for pre-releases so ALPHA/BETA/RC never become "latest".
-      # See https://sourceforge.net/p/forge/documentation/Using%20the%20Release%20API/
+      # SourceForge's "Download Latest Version" flag does not auto-follow new uploads.
+      # https://sourceforge.net/p/forge/documentation/Using%20the%20Release%20API/
       if: needs.setup.outputs.is-prerelease == 'false'
       env:
         SF_API_KEY: ${{ secrets.SOURCEFORGE_API_KEY }}
@@ -595,7 +591,6 @@ jobs:
           exit 1
         fi
         DIR="stable/${{ steps.vars.outputs.full }}"
-        # One file per platform (SourceForge allows a single default per OS).
         declare -A DEFAULTS=(
           [windows]="jsignpdf-${VERSION}-windows-x64.msi"
           [mac]="jsignpdf-${VERSION}-macos-aarch64.dmg"
@@ -608,8 +603,6 @@ jobs:
           echo "Setting default=${platform} -> ${file}"
           ok=false
           for attempt in $(seq 1 5); do
-            # On success SF returns HTTP 200 with the file object nested under
-            # .result, the new flags at .result.x_sf.default (comma-separated).
             body="$(curl -sS -L -H 'Accept: application/json' -X PUT \
               --data-urlencode "default=${platform}" \
               --data-urlencode "api_key=${SF_API_KEY}" \
@@ -618,8 +611,6 @@ jobs:
             code="${body##*$'\n'}"
             resp="${body%$'\n'*}"
             echo "  HTTP ${code}: ${resp}"
-            # Only accept a real success: 200 AND the platform now appears in
-            # result.x_sf.default. A null/redirect body must NOT pass.
             if [ "$code" = "200" ] \
                && echo "$resp" | jq -e --arg p "$platform" \
                     '(.result.x_sf.default // "") | split(",") | index($p)' >/dev/null 2>&1; then

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -480,8 +480,10 @@ jobs:
 
   publish-release:
     # Collects every asset, computes SHA-256 checksums, mirrors to SourceForge,
-    # and creates the GitHub Release. Flatpak is optional: if its job failed
-    # (e.g. SDK extension outage) we still publish the rest.
+    # points SourceForge's per-platform "Download Latest Version" defaults at the
+    # new files (final releases only), and creates the GitHub Release. Flatpak is
+    # optional: if its job failed (e.g. SDK extension outage) we still publish
+    # the rest.
     needs: [setup, fetch-zips, package, sign-windows, flatpak]
     # sign-windows is 'skipped' for pre-releases (unsigned Windows bits come
     # straight from the package job) and must be 'success' for final releases.
@@ -575,6 +577,54 @@ jobs:
         EOF
         cd ..
         rm -f private_key
+
+    - name: Set SourceForge default downloads (final releases only)
+      # Without this, SourceForge's per-platform "Download Latest Version" flag
+      # stays wherever it was last set (it does NOT auto-follow new uploads), so
+      # visitors keep getting an ancient installer. The Release API sets the
+      # default per file; PUTting the flag onto the new file moves it off the old
+      # one. Skipped for pre-releases so ALPHA/BETA/RC never become "latest".
+      # See https://sourceforge.net/p/forge/documentation/Using%20the%20Release%20API/
+      if: needs.setup.outputs.is-prerelease == 'false'
+      env:
+        SF_API_KEY: ${{ secrets.SOURCEFORGE_API_KEY }}
+      run: |
+        set -euo pipefail
+        if [ -z "${SF_API_KEY:-}" ]; then
+          echo "::error::SOURCEFORGE_API_KEY secret is not set"
+          exit 1
+        fi
+        DIR="stable/${{ steps.vars.outputs.full }}"
+        # One file per platform (SourceForge allows a single default per OS).
+        declare -A DEFAULTS=(
+          [windows]="jsignpdf-${VERSION}-windows-x64.msi"
+          [mac]="jsignpdf-${VERSION}-macos-aarch64.dmg"
+          [linux]="jsignpdf-${VERSION}-linux-x64.deb"
+          [others]="jsignpdf-${VERSION}-full.zip"
+        )
+        for platform in windows mac linux others; do
+          file="${DEFAULTS[$platform]}"
+          url="https://sourceforge.net/projects/jsignpdf/files/${DIR}/${file}"
+          echo "Setting default=${platform} -> ${file}"
+          ok=false
+          for attempt in $(seq 1 5); do
+            resp="$(curl -sS -H 'Accept: application/json' -X PUT \
+              --data-urlencode "default=${platform}" \
+              --data-urlencode "api_key=${SF_API_KEY}" \
+              "${url}")" || resp=''
+            if [ -n "$resp" ] && ! echo "$resp" | jq -e 'has("error")' >/dev/null 2>&1; then
+              echo "$resp" | jq -c '{name, download_label, default}' 2>/dev/null || echo "$resp"
+              ok=true
+              break
+            fi
+            echo "attempt ${attempt}/5 failed: ${resp:-<no response>}"
+            sleep 30
+          done
+          if [ "$ok" != true ]; then
+            echo "::error::Failed to set SourceForge default for ${platform} (${file})"
+            exit 1
+          fi
+        done
 
     - name: Create GitHub release with all assets
       env:

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -608,16 +608,25 @@ jobs:
           echo "Setting default=${platform} -> ${file}"
           ok=false
           for attempt in $(seq 1 5); do
-            resp="$(curl -sS -H 'Accept: application/json' -X PUT \
+            # On success SF returns HTTP 200 with the file object nested under
+            # .result, the new flags at .result.x_sf.default (comma-separated).
+            body="$(curl -sS -L -H 'Accept: application/json' -X PUT \
               --data-urlencode "default=${platform}" \
               --data-urlencode "api_key=${SF_API_KEY}" \
-              "${url}")" || resp=''
-            if [ -n "$resp" ] && ! echo "$resp" | jq -e 'has("error")' >/dev/null 2>&1; then
-              echo "$resp" | jq -c '{name, download_label, default}' 2>/dev/null || echo "$resp"
+              -w $'\n%{http_code}' \
+              "${url}")" || body=$'\n000'
+            code="${body##*$'\n'}"
+            resp="${body%$'\n'*}"
+            echo "  HTTP ${code}: ${resp}"
+            # Only accept a real success: 200 AND the platform now appears in
+            # result.x_sf.default. A null/redirect body must NOT pass.
+            if [ "$code" = "200" ] \
+               && echo "$resp" | jq -e --arg p "$platform" \
+                    '(.result.x_sf.default // "") | split(",") | index($p)' >/dev/null 2>&1; then
               ok=true
               break
             fi
-            echo "attempt ${attempt}/5 failed: ${resp:-<no response>}"
+            echo "  attempt ${attempt}/5 failed; retrying in 30s"
             sleep 30
           done
           if [ "$ok" != true ]; then


### PR DESCRIPTION
Fixes #485.

SourceForge's per-platform **"Download Latest Version"** flag does not auto-follow new uploads, so it stayed pinned to the ancient `JSignPdf_setup_2.3.0.exe` (reported by @LadaN62 in #479).

## Change
After the SFTP upload in `publish-release`, call the [SourceForge Release API](https://sourceforge.net/p/forge/documentation/Using%20the%20Release%20API/) to set each platform's default onto the newly published file:

| platform | file |
|---|---|
| `windows` | `jsignpdf-<v>-windows-x64.msi` |
| `mac` | `jsignpdf-<v>-macos-aarch64.dmg` |
| `linux` | `jsignpdf-<v>-linux-x64.deb` |
| `others` | `jsignpdf-<v>-full.zip` |

- Gated on `is-prerelease == 'false'` — ALPHA/BETA/RC/MILESTONE never become "latest".
- Retries each PUT up to 5× (30s apart); fails the job if any platform can't be set.

## Required before this works
Add a repo secret **`SOURCEFORGE_API_KEY`** (the account's *Releases API Key* from the SourceForge account page). The step errors early if it's missing.

## Note
The flag only updates on the next final release. To fix the current stale 2.3.0 default sooner, the four API PUTs can be run manually against the current stable files.